### PR TITLE
Fix `put` calculation

### DIFF
--- a/src/24LC256.h
+++ b/src/24LC256.h
@@ -62,50 +62,61 @@ struct E24LC256 {
     // TODO: compare 64-byte pages on Arduino.
     //
     template <typename T> T &put(uint16_t address, T &t) {
-      uint16_t size = sizeof(T);                              // Size of the object given: the number of bytes to write.
+      const uint16_t initsize = sizeof(T);                    // Size of the object given: the number of bytes to write.
       uint8_t *ptr = (uint8_t*) &t;                           // Cast object to byte array for easier handling.
-      uint8_t pageSize = 32;                                  // The size of the I2C buffer for AVR Arduinos, use that for page size.
+
 #ifdef ESP8266
-      pageSize = 64;                                          // Page size of the EEPROM (ESP's I2C buffer is 128 bytes).
+      const uint16_t pageSize = 64;                           // Page size of the EEPROM (ESP's I2C buffer is 128 bytes).
+#else
+      const uint16_t pageSize = 32;                           // The size of the I2C buffer for AVR Arduinos, use that for page size.
 #endif
-      if (ackPolling()) {                                     // Make sure the EEPROM is ready to communicate.
-        uint8_t firstPageSize = pageSize * (address / pageSize + 1) - address; // Bytes until the next page boundary.
-        if (firstPageSize > size) {                           // Make sure it's not greater than the total we have to check.
-          firstPageSize = size;
+
+        /* We have three potential numbers of bytes to write:
+         * 1) The maximum we can fit in the buffer - although the buffer is `pageSize`,
+         *    during read/write operations two of those bytes are just for the address,
+         *    leaving `pageSize - 2` bytes for data.
+         * 2) The number of bytes until the page boundary
+         * 3) The remaining size of the data structure
+         *
+         * We can only ever write the smallest of these numbers. Once written,
+         * update the address, ptr values and remaining size.
+         * If remaining size is zero, we're done.
+         */
+
+        const uint16_t putSize = pageSize - 2;        // Max buffer size
+        uint16_t remainingDataSize = initsize;        // Remaining number of bytes to write
+
+      while (remainingDataSize > 0) {
+        uint16_t remainingPageSize = pageSize * (address / pageSize + 1) - address; // Bytes until the next page boundary.
+
+        uint16_t nbytes = putSize;
+        if (remainingPageSize < nbytes) { nbytes = remainingPageSize; }
+        if (remainingDataSize < nbytes) { nbytes = remainingDataSize; }
+
+        if (!ackPolling()) {
+          return t;
         }
-        readBytes(address, readBuffer, firstPageSize);        // Read the first page, and compare it.
-        if (compareBytes(readBuffer, ptr, firstPageSize) == false) {
-          writeBytes(address, ptr, firstPageSize);            // If page different: write the new data to the EEPROM.
+
+        readBytes(address, readBuffer, nbytes);        // Read the first page, and compare it.
+        if (compareBytes(readBuffer, ptr, nbytes) == false) {
+          writeBytes(address, ptr, nbytes);            // If page different: write the new data to the EEPROM.
           ackPolling();                                       // Wait for EEPROM to finish writing before continuing with the next block.
         }
-        ptr += firstPageSize;                                 // Update the data pointer.
-        if (size > firstPageSize) {                           // Check whether we have more bytes to write.
-          uint8_t nextPageSize;
-          for (uint16_t i = firstPageSize; i < size; i += pageSize) { // We have to write data pageSize bytes (or less) at a time.
-            nextPageSize = pageSize;
-            if (i + pageSize > size) {                        // Next page to check: pageSize bytes or less.
-              nextPageSize = size - i;
-            }
-            readBytes(address + i, readBuffer, nextPageSize); // Read current data; compare to new data; write if different.
-            if (compareBytes(readBuffer, ptr, nextPageSize) == false) {
-              writeBytes(address + i, ptr, nextPageSize);
-              if (i + pageSize < size) {                      // We're not done yet!
-                ackPolling();                                 // Wait for EEPROM to finish writing before continuing with the next block.
-              }
-            }
-            ptr += nextPageSize;                              // Increase the data pointer.
-          }
-        }
+        address += nbytes;
+        ptr += nbytes;
+        remainingDataSize -= nbytes;
       }
+
       return t;
     }
 
     template <typename T> T &get(uint16_t address, T &t) {    // Get any type of data from the EEPROM.
       uint16_t size = sizeof(T);                              // The size of the type: amount of bytes to read.
       uint8_t *ptr = (uint8_t*) &t;                           // Cast object to byte array for easier handling.
-      uint8_t bufferSize = 32;                                // Arduino's default I2C buffer size - don't read more than that in one go.
 #ifdef ESP8266
-      bufferSize = 128;                                       // ESP8266's default I2C buffer size - don't read more than that in one go.
+      const uint8_t bufferSize = 128;                         // ESP8266's default I2C buffer size - don't read more than that in one go.
+#else
+      const uint8_t bufferSize = 32;                          // Arduino's default I2C buffer size - don't read more than that in one go.
 #endif
 
       if (ackPolling()) {                                     // Make sure the EEPROM is ready to communicate.


### PR DESCRIPTION
The `put` function, which lets you save arbitrary data structures to the EEPROM, was assuming a 32 byte I2C buffer. The buffer is indeed 32 bytes, but in a write operation, the first two of those bytes are the 16-bit address, leaving only 30 bytes for data. Attempting to write 32 bytes will discard the final two bytes. The `get` counterpart does not have this problem: it writes the 16-bit address but then ends communication. After that it requests data from the now-empty buffer - up to 32 bytes.

Back to `put`: there's an extra complication. The EEPROM is split into physical pages of 32 bytes. Any attempt to write past a page boundary will wrap to the start of the page and overwrite. So we have three numbers to keep track of:
1) the buffer size minus 2 bytes
2) the remaining number of bytes to the page boundary
3) the remaining number of bytes in the original data structure

We can only ever write the smallest of these numbers. After writing, move the starting address & pointer to the data structure; and decrease the remaining number of bytes. Repeat until there are no more bytes to write.